### PR TITLE
Bump package version to 0.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@eda-labs/topo-builder",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eda-labs/topo-builder",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eda-labs/topo-builder",
   "type": "module",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "EDA Topology Builder app and reusable React library.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Update `package.json` to version `0.2.4`
- Update `package-lock.json` root package metadata to `0.2.4`

## Why
The `v0.2.4` publish workflow failed because the tag version did not match the package metadata. The workflow saw tag `v0.2.4` while `package.json` still reported `0.2.3`.

## Validation
- `npm run build:lib`
- `npm pack --dry-run --json`